### PR TITLE
OK button after loggin fail does not restart login

### DIFF
--- a/src/js/CloudExplorer.jsx
+++ b/src/js/CloudExplorer.jsx
@@ -68,7 +68,7 @@ export default class CloudExplorer extends React.Component {
       this.ls();
     })
     .catch((e) => {
-      if (oldProps && oldProps.path && oldProps.path.lentgh !== 0) {
+      if (oldProps && oldProps.path && oldProps.path.length !== 0) {
         this.props.onCd(oldProps.path);
       }
       this.onUnifileError(e);

--- a/src/js/CloudExplorer.jsx
+++ b/src/js/CloudExplorer.jsx
@@ -138,7 +138,7 @@ export default class CloudExplorer extends React.Component {
           ), () => {
           // Ok, to restart the service must do this.cd() must know the service name.
             this.unifile.auth(this.props.path[0])
-            .catch(() => this.cd([this.props.path[0]]))     
+            .catch(() => this.cd([]))     
             .then(() => this.ls());
           }, () => {
 

--- a/src/js/CloudExplorer.jsx
+++ b/src/js/CloudExplorer.jsx
@@ -68,7 +68,7 @@ export default class CloudExplorer extends React.Component {
       this.ls();
     })
     .catch((e) => {
-      if (oldProps && oldProps.path) {
+      if (oldProps && oldProps.path && oldProps.path.lentgh !== 0) {
         this.props.onCd(oldProps.path);
       }
       this.onUnifileError(e);
@@ -136,9 +136,9 @@ export default class CloudExplorer extends React.Component {
               <p>{ this.LOGGEDOUT_DETAILS }</p>
             </section>
           ), () => {
-          // Ok
+          // Ok, to restart the service must do this.cd() must know the service name.
             this.unifile.auth(this.props.path[0])
-            .catch(() => this.cd([]))
+            .catch(() => this.cd([this.props.path[0]]))     
             .then(() => this.ls());
           }, () => {
 


### PR DESCRIPTION
After a login fails a modal windows appears and tell that login has failed and that you can press OK button for login again, but this doesn't work so. Ok and Cancel button does identical actions.

I've seen in CloudExplorer.jsx, line 71, in a catch o unifile.cd

if (oldProps && oldProps.path) { this.props.onCd(oldProps.path); }
This happens after a bad login. I suppose that it tries to change path to previous folder (previous service????), I think that if there is a login fail the first action is to process this error.
More: in the Ok process of the modal dialog window opened after login fails, the service name has dissapeared (because of the props.onCd in line 71).
And the Ok process (line 140) I see:

this.unifile.auth(this.props.path[0])
.catch(() => this.cd([]))
.then(() => this.ls());
catch execute this.cd([]) with a blank param, I think it must be [this.props.path[0]], so app inits again the login process.

After discover these two points (that's after several days and nights, thousand of coffees and some panic attacks):
I modified the if sentences line 71 , now it's

if (oldProps && oldProps.path && oldProps.path.length != 0)
and modified line 146 to

.catch(() => this.cd([this.props.path[0]])
After that I got that the ok button of the error window (that after loggin fails) works and begin the login process again.